### PR TITLE
Remove `::Rails.application.eager_load!`

### DIFF
--- a/lib/rails-mermaid_erd/builder.rb
+++ b/lib/rails-mermaid_erd/builder.rb
@@ -8,7 +8,6 @@ class RailsMermaidErd::Builder
         Relations: []
       }
 
-      ::Rails.application.eager_load!
       ::ActiveRecord::Base.descendants.sort_by(&:name).each do |defined_model|
         next unless defined_model.table_exists?
         next if defined_model.name.include?("HABTM_")


### PR DESCRIPTION
I'm not sure why it necessary (or unnecessary) but actually it shows this error in my environment:

```
rails aborted!
ActiveRecord::ConnectionNotEstablished: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
	Is the server running locally and accepting connections on that socket?
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/postgresql_adapter.rb:87:in `rescue in new_client'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/postgresql_adapter.rb:77:in `new_client'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/postgresql_adapter.rb:37:in `postgresql_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:656:in `public_send'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:656:in `new_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:700:in `checkout_new_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:679:in `try_to_checkout_new_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:640:in `acquire_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:341:in `checkout'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:181:in `connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_adapters/abstract/connection_handler.rb:211:in `retrieve_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_handling.rb:313:in `retrieve_connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/connection_handling.rb:280:in `connection'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/activerecord-7.0.4/lib/active_record/model_schema.rb:407:in `table_exists?'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rails-mermaid_erd-0.4.2/lib/rails-mermaid_erd/builder.rb:13:in `block in model_data'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rails-mermaid_erd-0.4.2/lib/rails-mermaid_erd/builder.rb:12:in `each'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rails-mermaid_erd-0.4.2/lib/rails-mermaid_erd/builder.rb:12:in `model_data'
/home/runner/work/xxxxx/xxxxx/config/environments/development.rb:119:in `model_data'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rails-mermaid_erd-0.4.2/lib/rails-mermaid_erd.rb:20:in `block in <module:RailsMermaidErd>'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/sentry-ruby-5.8.0/lib/sentry/rake.rb:26:in `execute'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:24:in `block (2 levels) in perform'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/command.rb:51:in `invoke'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/railties-7.0.4/lib/rails/commands.rb:18:in `<main>'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/runner/work/xxxxx/xxxxx/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
```

After I deleted that line and overridden it in Gemfile, it works properly.

```
gem 'rails-mermaid_erd', github: "sters/rails-mermaid_erd"
```
