### PR TITLE
Avoid unnecessary loading on Rails boot

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,13 +21,23 @@ ERDは自由自在に生成できます。
 導入したいRailsアプリケーションのGemfileに以下の行を追加してください。
 
 ```ruby
-gem "rails-mermaid_erd", group: :development
+gem "rails-mermaid_erd", group: :development, require: false
 ```
 
 次に、以下のコマンドを実行してGemをインストールします。
 
 ```bash
 $ bundle install
+```
+
+次に、Rakefileに以下の行を追加してください。
+
+```ruby
+begin
+  require "rails-mermaid_erd"
+rescue LoadError
+  # Do nothing.
+end
 ```
 
 ## 使い方

--- a/README.md
+++ b/README.md
@@ -21,13 +21,23 @@ The editor is a single HTML file, so the entire editor can be shared.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem "rails-mermaid_erd", group: :development
+gem "rails-mermaid_erd", group: :development, require: false
 ```
 
 And then execute:
 
 ```bash
 $ bundle install
+```
+
+Add this line to your application's Rakefile:
+
+```ruby
+begin
+  require "rails-mermaid_erd"
+rescue LoadError
+  # Do nothing.
+end
 ```
 
 ## Usage


### PR DESCRIPTION
With the current instruction described, this library is always loaded even outside of cases where this Rake task is executed, so how about changing the installation section to avoid this?