### PR TITLE
Add a new config option

### DIFF
--- a/docs/example.yml
+++ b/docs/example.yml
@@ -1,3 +1,4 @@
 # result path
 # default "mermaid_erd/index.html"
 result_path: doc/erd.html
+all_models_selected: false

--- a/lib/rails-mermaid_erd.rb
+++ b/lib/rails-mermaid_erd.rb
@@ -22,6 +22,7 @@ module RailsMermaidErd
     version = VERSION
     app_name = ::Rails.application.class.try(:parent_name) || ::Rails.application.class.try(:module_parent_name)
     logo = File.read(File.expand_path("./assets/logo.svg", __dir__))
+    configuration = RailsMermaidErd.configuration
     erb = ERB.new(File.read(File.expand_path("./templates/index.html.erb", __dir__)))
     result_html = erb.result(binding)
 

--- a/lib/rails-mermaid_erd/configuration.rb
+++ b/lib/rails-mermaid_erd/configuration.rb
@@ -1,11 +1,12 @@
 require "yaml"
 
 class RailsMermaidErd::Configuration
-  attr_accessor :result_path
+  attr_accessor :result_path, :all_models_selected
 
   def initialize
     config = {
-      result_path: "mermaid_erd/index.html"
+      result_path: "mermaid_erd/index.html",
+      all_models_selected: true,
     }
 
     config_file = Rails.root.join("config/mermaid_erd.yml")
@@ -15,5 +16,6 @@ class RailsMermaidErd::Configuration
     end
 
     @result_path = config[:result_path]
+    @all_models_selected = config[:all_models_selected]
   end
 end

--- a/lib/rails-mermaid_erd/configuration.rb
+++ b/lib/rails-mermaid_erd/configuration.rb
@@ -15,7 +15,14 @@ class RailsMermaidErd::Configuration
       config = config.merge(custom_config)
     end
 
-    @result_path = config[:result_path]
     @all_models_selected = config[:all_models_selected]
+    @result_path = config[:result_path]
+  end
+
+  def to_json
+    {
+      allModelsSelected: @all_models_selected,
+      resultPath: @result_path
+    }.to_json
   end
 end

--- a/lib/templates/index.html.erb
+++ b/lib/templates/index.html.erb
@@ -267,6 +267,7 @@
   <script src="https://unpkg.com/vue@3.2.40/dist/vue.global.js"></script>
 
   <script>window.SCHEMA_DATA=<%= result.to_json %></script>
+  <script>window.CONFIG_DATA=<%= configuration.to_json %></script>
   <script>
     window.i18n = {
       en: {
@@ -351,6 +352,7 @@
           ...window.SCHEMA_DATA,
           Models: window.SCHEMA_DATA.Models.sort((a, b) => a.ModelName < b.ModelName ? -1 : 1)
         }
+        const configData = { ...window.CONFIG_DATA }
         const selectModels = Vue.ref([])
         const isPreviewRelations = Vue.ref(false)
         const isShowRelationComment = Vue.ref(false)
@@ -406,9 +408,11 @@
 
         const reset = () => {
           selectModels.value = []
-          schemaData.Models.forEach((model) => {
-            selectModels.value.push(model.ModelName)
-          })
+          if (configData.allModelsSelected) {
+            schemaData.Models.forEach((model) => {
+              selectModels.value.push(model.ModelName)
+            })
+          }
           isPreviewRelations.value = false
           isShowRelationComment.value = false
           isShowKey.value = false

--- a/spec/fixtures/files/configurations/valid.yml
+++ b/spec/fixtures/files/configurations/valid.yml
@@ -1,3 +1,4 @@
 # result path
 # default "mermaid_erd/index.html"
 result_path: doc/erd.html
+all_models_selected: false

--- a/spec/rails-mermaid_erd/configration_spec.rb
+++ b/spec/rails-mermaid_erd/configration_spec.rb
@@ -6,6 +6,7 @@ describe RailsMermaidErd::Configuration do
   context "when the config file does not exist" do
     it "return default config value" do
       expect(configuration.result_path).to eq("mermaid_erd/index.html")
+      expect(configuration.all_models_selected).to eq(true)
     end
   end
 
@@ -18,6 +19,7 @@ describe RailsMermaidErd::Configuration do
     end
     it "return overwrite config value" do
       expect(configuration.result_path).to eq("doc/erd.html")
+      expect(configuration.all_models_selected).to eq(false)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?

Add new config option
```
all_models_selected: true
```
The default value is `true`, but config file can change it to `false` if needed to prevent all models from being checked on initial page load. 


## Why?

For bigger rails applications, with lots of models, the first load of the diagram is slow and not useful as everything is very tiny.

![image](https://github.com/user-attachments/assets/14d3c72c-dc73-435b-a38c-3d027eb38afa)


## Note - 
Please feel free to modify this PR if you see issues!

Thank you for your work on this gem! 
ありがとうございます!