### PR TITLE
added configurarations options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The setting items are as follows.
 | key | description | default |
 | --- | --- | --- |
 | `result_path` | Destination of generated files. | `mermaid_erd/index.html` |
+| `models_list` | A method that would return a list of active record models | `::ActiveRecord::Base.descendants.sort_by(&:name)` |
 
 <!--
 TODO:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The setting items are as follows.
 | --- | --- | --- |
 | `result_path` | Destination of generated files. | `mermaid_erd/index.html` |
 | `models_list` | A method that would return a list of active record models | `::ActiveRecord::Base.descendants.sort_by(&:name)` |
+| `hide_columns` | Hide columns by default for readability purpose | `false` |
 
 <!--
 TODO:

--- a/lib/rails-mermaid_erd.rb
+++ b/lib/rails-mermaid_erd.rb
@@ -11,7 +11,7 @@ module RailsMermaidErd
 
   class << self
     def configuration
-      @configuration ||= RailsMermaidErd::Configuration.new
+      @configuration ||= RailsMermaidErd::Configuration.new(ENV['CONFIG_FILE'] )
     end
   end
 

--- a/lib/rails-mermaid_erd/builder.rb
+++ b/lib/rails-mermaid_erd/builder.rb
@@ -150,17 +150,20 @@ class RailsMermaidErd::Builder
 
     # Doc: https://guides.rubyonrails.org/association_basics.html
     def get_reflection_model_name(reflection)
-      if reflection.options[:class_name]
-        reflection.options[:class_name].to_s.classify
-      elsif reflection.options[:through]
+      if reflection.is_a?(ActiveRecord::Reflection::ThroughReflection)
         if reflection.options[:source]
           reflection.options[:source].to_s.classify
+        elsif reflection.options[:source_type]
+          reflection.options[:source_type].to_s.classify
         else
-          reflection.class_name
+          reflection.name.to_s.classify
         end
+      elsif reflection.options[:class_name]
+        reflection.options[:class_name]
       else
         reflection.class_name
       end
     end
+
   end
 end

--- a/lib/rails-mermaid_erd/builder.rb
+++ b/lib/rails-mermaid_erd/builder.rb
@@ -9,7 +9,8 @@ class RailsMermaidErd::Builder
       }
 
       ::Rails.application.eager_load!
-      ::ActiveRecord::Base.descendants.sort_by(&:name).each do |defined_model|
+
+      eval(RailsMermaidErd.configuration.models_list).each do |defined_model|
         next unless defined_model.table_exists?
         next if defined_model.name.include?("HABTM_")
         next if defined_model.table_name.blank?

--- a/lib/rails-mermaid_erd/configuration.rb
+++ b/lib/rails-mermaid_erd/configuration.rb
@@ -3,11 +3,13 @@ require "yaml"
 class RailsMermaidErd::Configuration
   attr_accessor :result_path
   attr_accessor :models_list
+  attr_accessor :hide_columns
 
   def initialize
     config = {
       result_path: "mermaid_erd/index.html",
-      models_list: "::ActiveRecord::Base.descendants.sort_by(&:name)"
+      models_list: "::ActiveRecord::Base.descendants.sort_by(&:name)",
+      hide_columns: false
     }
 
     config_file = Rails.root.join("config/mermaid_erd.yml")
@@ -18,5 +20,6 @@ class RailsMermaidErd::Configuration
 
     @result_path = config[:result_path]
     @models_list = config[:models_list]
+    @hide_columns = config[:hide_columns]
   end
 end

--- a/lib/rails-mermaid_erd/configuration.rb
+++ b/lib/rails-mermaid_erd/configuration.rb
@@ -2,10 +2,12 @@ require "yaml"
 
 class RailsMermaidErd::Configuration
   attr_accessor :result_path
+  attr_accessor :models_list
 
   def initialize
     config = {
-      result_path: "mermaid_erd/index.html"
+      result_path: "mermaid_erd/index.html",
+      models_list: "::ActiveRecord::Base.descendants.sort_by(&:name)"
     }
 
     config_file = Rails.root.join("config/mermaid_erd.yml")
@@ -15,5 +17,6 @@ class RailsMermaidErd::Configuration
     end
 
     @result_path = config[:result_path]
+    @models_list = config[:models_list]
   end
 end

--- a/lib/rails-mermaid_erd/configuration.rb
+++ b/lib/rails-mermaid_erd/configuration.rb
@@ -5,14 +5,16 @@ class RailsMermaidErd::Configuration
   attr_accessor :models_list
   attr_accessor :hide_columns
 
-  def initialize
+  def initialize(config_file)
+    config_file = config_file || "config/mermaid_erd.yml"
     config = {
       result_path: "mermaid_erd/index.html",
       models_list: "::ActiveRecord::Base.descendants.sort_by(&:name)",
       hide_columns: false
     }
+    puts "config_file: #{config_file}"
+    config_file = Rails.root.join(config_file)
 
-    config_file = Rails.root.join("config/mermaid_erd.yml")
     if File.exist?(config_file)
       custom_config = YAML.load(config_file.read).symbolize_keys
       config = config.merge(custom_config)
@@ -21,5 +23,6 @@ class RailsMermaidErd::Configuration
     @result_path = config[:result_path]
     @models_list = config[:models_list]
     @hide_columns = config[:hide_columns]
+    puts "models_list: #{@models_list}"
   end
 end

--- a/lib/templates/index.html.erb
+++ b/lib/templates/index.html.erb
@@ -267,6 +267,8 @@
   <script src="https://unpkg.com/vue@3.2.40/dist/vue.global.js"></script>
 
   <script>window.SCHEMA_DATA=<%= result.to_json %></script>
+  <script>window.CONFIG_DATA=<%= configuration.to_json %></script>
+
   <script>
     window.i18n = {
       en: {
@@ -351,12 +353,13 @@
           ...window.SCHEMA_DATA,
           Models: window.SCHEMA_DATA.Models.sort((a, b) => a.ModelName < b.ModelName ? -1 : 1)
         }
+        const configData = { ...window.CONFIG_DATA }
         const selectModels = Vue.ref([])
         const isPreviewRelations = Vue.ref(false)
         const isShowRelationComment = Vue.ref(false)
         const isShowKey = Vue.ref(false)
         const isShowComment = Vue.ref(false)
-        const isHideColumns = Vue.ref(false)
+        const isHideColumns = Vue.ref(window.CONFIG_DATA.hide_columns)
 
         const scale = Vue.ref(1)
         const posX = Vue.ref(0)
@@ -413,7 +416,7 @@
           isShowRelationComment.value = false
           isShowKey.value = false
           isShowComment.value = false
-          isHideColumns.value = false
+          isHideColumns.value = window.CONFIG_DATA.hide_columns
           updateHash()
         }
 


### PR DESCRIPTION
Added a configuration key called models_list, in case someone needs to draw a chart for a subset of the models in the rails application.

example configuration:

`models_list:  User.descendants`

default is still `::ActiveRecord::Base.descendants.sort_by(&:name)`

the method could be anything that will return an array of active record models or even a string containing an array of models:

`"[User, Role]"`

Also added

`hide_columns: true`

to hide columns by default for readability purpose

not settings the option or setting it to false will show columns like it is in the  current setting