### PR TITLE
Document contribution conventions for Claude Code and contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ A Ruby gem that adds a `mermaid_erd` Rake task to a host Rails app. The task int
 
 ## Commands
 
-All commands run inside the dev container (`docker compose exec devcontainer ...`) unless noted. PostgreSQL is required for tests because `Builder` calls `ActiveRecord::Schema.foreign_keys` and `connection.table_comment`.
+All commands run inside the dev container (`docker compose exec devcontainer ...`) unless noted. The dummy app and CI both run on PostgreSQL 14 (`pg` is the only DB driver wired into the dev container), so the test DB must be Postgres.
 
 ```bash
 # First-time setup (after `docker compose up -d`):
@@ -33,12 +33,10 @@ CI (`.github/workflows/run-test.yml`, `coding-style-check.yml`) uses `compose.ci
 
 ## Architecture
 
-The runtime split is small but worth keeping straight:
-
 - **`lib/rails-mermaid_erd.rb`** — declares the `mermaid_erd` Rake task. It calls `Builder.model_data`, then evaluates `lib/templates/index.html.erb` with `version`, `app_name`, `logo`, and `result` (the schema dump) in scope, and writes the rendered HTML to the path from `Configuration#result_path`. ERB binding is the entire integration contract between Ruby and the front-end.
 
 - **`lib/rails-mermaid_erd/builder.rb`** — the only nontrivial Ruby. Calls `Rails.application.eager_load!`, walks `ActiveRecord::Base.descendants`, and emits `{Models: [...], Relations: [...]}`. Two things to know before touching it:
-  1. **Relation deduplication is direction-aware.** For each model it iterates `has_many`, `has_and_belongs_to_many`, `belongs_to`, `has_one` and checks `Relations` for a reverse pair (matching `LeftModelName`/`RightModelName` and the `Line` style `--` vs `..`). If found, it *merges* (appends the new association name into `Comment`, possibly upgrades cardinality glyphs like `||` → `|o` for optional `belongs_to`). If not, it appends a new tuple. The `Line: ".."` vs `"--"` distinction is how `through:` associations stay separate from direct ones.
+  1. **Relation deduplication is direction-aware, but the `Line`-style filter is selective.** For each model it iterates `has_many`, `has_and_belongs_to_many`, `belongs_to`, `has_one` and looks up a reverse pair in `Relations` by matching `LeftModelName`/`RightModelName`. The `has_many` and `has_one` branches *also* filter on `Line` style (`".."` for `through:`, `"--"` otherwise — `builder.rb:48-54, 120-126`), so direct and `through:` associations don't collapse into each other. The `belongs_to` (`builder.rb:94`) and `has_and_belongs_to_many` (`builder.rb:76`) branches match on names only — don't add a `Line` filter there, it would break HABTM and BT-vs-pre-existing-HM merges. When a reverse pair is found, the entry is *merged* (the new association name is appended to `Comment`, and cardinality glyphs may upgrade `||` → `|o` for optional `belongs_to`).
   2. **Model name resolution** goes through `get_reflection_model_name`, which honors `class_name:`, then `through:` + `source:`, else falls back to `reflection.class_name`. The dummy app deliberately exercises all three (`Author` is `users`, `comment_posts` is `has_many :through`, `images` uses `class_name: "UserImage"`).
 
   HABTM join tables emitted by Rails with `HABTM_` in the name and tables that don't exist yet are skipped — don't add filtering elsewhere.
@@ -57,7 +55,7 @@ Detailed in `docs/DEVELOPMENT.md` ("Contributing" section). Highlights to apply 
 
 - **Language**: every PR title, PR body, issue, commit message, code comment, and `/docs` file is written in **English**. The README is the only bilingual artifact (`README.md` + `README.ja.md` — update both together). UI strings in `lib/templates/index.html.erb` have paired `en`/`ja` entries in the `window.i18n` block; keep them in sync.
 - **Branches**: `feature/<kebab-case>` for work, `release/vX.Y.Z` for releases. Target `develop` for everything except the release `→ main` PR.
-- **Commit messages**: English, imperative mood, single subject line. **No Conventional Commits prefixes** (`feat:`/`fix:` are not used here). Examples from history: `Add zoom and drag mouse controls`, `Migrate to Docker Compose V2`, `Fix a typo`. Version-bump commits are bare `vX.Y.Z`.
+- **Commit messages**: English, imperative mood, single subject line. **No Conventional Commits prefixes** (`feat:`/`fix:` are not used here). Examples from history: `Add zoom and drag mouse controls`, `Fix a typo`, `Avoid unnecessary loading on Rails boot`. Version-bump commits use the bare subject `vX.Y.Z`, hand-written after `bundle exec bump <level> --no-commit` (see `RELEASE.md`) so the bump can be grouped with the regenerated `docs/example.html` and `docs/screen_shot.png`.
 - **PR titles**: same imperative-English style as commits. Release PRs use the fixed title `Release/vX.Y.Z`.
 - **PR bodies**: empty bodies are acceptable for small PRs (the merged history confirms this). For non-trivial changes, use the `### Motivation / Background` + `### Detail` structure modeled by [PR #84](https://github.com/koedame/rails-mermaid_erd/pull/84). Attach screenshots for UI changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Ruby gem that adds a `mermaid_erd` Rake task to a host Rails app. The task introspects the app's ActiveRecord models and emits a single self-contained HTML file at `<app_root>/mermaid_erd/index.html` containing a Vue 3 + Mermaid.js editor (Tailwind + i18n en/ja, all inlined — no build step). The generated file is meant to be opened directly in a browser or hosted statically.
+
+## Commands
+
+All commands run inside the dev container (`docker compose exec devcontainer ...`) unless noted. PostgreSQL is required for tests because `Builder` calls `ActiveRecord::Schema.foreign_keys` and `connection.table_comment`.
+
+```bash
+# First-time setup (after `docker compose up -d`):
+docker compose exec -w /workspace/spec/dummy devcontainer bundle exec rails db:setup RAILS_ENV=test
+
+# Run the full RSpec suite (coverage via SimpleCov drops in /coverage):
+docker compose exec devcontainer bundle exec rspec
+
+# Run a single spec file or example:
+docker compose exec devcontainer bundle exec rspec spec/rails-mermaid_erd/builder/model_data_spec.rb
+docker compose exec devcontainer bundle exec rspec spec/rails-mermaid_erd/builder/model_data_spec.rb:6
+
+# Lint (StandardRb — enforced in CI):
+docker compose exec devcontainer bundle exec standardrb
+docker compose exec devcontainer bundle exec standardrb --fix
+
+# Exercise the generator end-to-end against the dummy app — writes spec/dummy/mermaid_erd/index.html:
+docker compose exec -w /workspace/spec/dummy devcontainer bundle exec rails mermaid_erd RAILS_ENV=test
+```
+
+CI (`.github/workflows/run-test.yml`, `coding-style-check.yml`) uses `compose.ci.yml` instead of `compose.yml` — they are not interchangeable (different container names, mount paths, env wiring).
+
+## Architecture
+
+The runtime split is small but worth keeping straight:
+
+- **`lib/rails-mermaid_erd.rb`** — declares the `mermaid_erd` Rake task. It calls `Builder.model_data`, then evaluates `lib/templates/index.html.erb` with `version`, `app_name`, `logo`, and `result` (the schema dump) in scope, and writes the rendered HTML to the path from `Configuration#result_path`. ERB binding is the entire integration contract between Ruby and the front-end.
+
+- **`lib/rails-mermaid_erd/builder.rb`** — the only nontrivial Ruby. Calls `Rails.application.eager_load!`, walks `ActiveRecord::Base.descendants`, and emits `{Models: [...], Relations: [...]}`. Two things to know before touching it:
+  1. **Relation deduplication is direction-aware.** For each model it iterates `has_many`, `has_and_belongs_to_many`, `belongs_to`, `has_one` and checks `Relations` for a reverse pair (matching `LeftModelName`/`RightModelName` and the `Line` style `--` vs `..`). If found, it *merges* (appends the new association name into `Comment`, possibly upgrades cardinality glyphs like `||` → `|o` for optional `belongs_to`). If not, it appends a new tuple. The `Line: ".."` vs `"--"` distinction is how `through:` associations stay separate from direct ones.
+  2. **Model name resolution** goes through `get_reflection_model_name`, which honors `class_name:`, then `through:` + `source:`, else falls back to `reflection.class_name`. The dummy app deliberately exercises all three (`Author` is `users`, `comment_posts` is `has_many :through`, `images` uses `class_name: "UserImage"`).
+
+  HABTM join tables emitted by Rails with `HABTM_` in the name and tables that don't exist yet are skipped — don't add filtering elsewhere.
+
+- **`lib/rails-mermaid_erd/configuration.rb`** — reads `config/mermaid_erd.yml` from the host app via `Rails.root`. Only `result_path` exists today; defaults to `mermaid_erd/index.html`. Keep new keys backwards-compatible (the merge happens on top of a hardcoded default hash).
+
+- **`lib/templates/index.html.erb`** — ~870 lines of Vue 3 (CDN), Mermaid.js, and Tailwind, all in one file. Schema is injected via `window.SCHEMA_DATA = <%= result.to_json %>`. UI state (selected models, toggles) is serialized to the URL hash as base64 JSON, so links are shareable. Any new field you add in `Builder` is visible here automatically via that JSON dump — coordinate naming. i18n strings live in the `window.i18n` block; both `en` and `ja` must be kept in sync.
+
+## Test strategy
+
+`spec/dummy` is a real (minimal) Rails app whose models intentionally cover every association edge case the builder handles — read `spec/dummy/app/models/*.rb` and `spec/dummy/db/schema.rb` as the spec of the spec. When changing `Builder`, the right move is usually to add a model/association to the dummy app and extend `spec/rails-mermaid_erd/builder/model_data_spec.rb` rather than mocking; the expected arrays in that file are exhaustive `match_array` assertions, so additions there are deliberate.
+
+## Contribution conventions
+
+Detailed in `docs/DEVELOPMENT.md` ("Contributing" section). Highlights to apply without re-reading:
+
+- **Language**: every PR title, PR body, issue, commit message, code comment, and `/docs` file is written in **English**. The README is the only bilingual artifact (`README.md` + `README.ja.md` — update both together). UI strings in `lib/templates/index.html.erb` have paired `en`/`ja` entries in the `window.i18n` block; keep them in sync.
+- **Branches**: `feature/<kebab-case>` for work, `release/vX.Y.Z` for releases. Target `develop` for everything except the release `→ main` PR.
+- **Commit messages**: English, imperative mood, single subject line. **No Conventional Commits prefixes** (`feat:`/`fix:` are not used here). Examples from history: `Add zoom and drag mouse controls`, `Migrate to Docker Compose V2`, `Fix a typo`. Version-bump commits are bare `vX.Y.Z`.
+- **PR titles**: same imperative-English style as commits. Release PRs use the fixed title `Release/vX.Y.Z`.
+- **PR bodies**: empty bodies are acceptable for small PRs (the merged history confirms this). For non-trivial changes, use the `### Motivation / Background` + `### Detail` structure modeled by [PR #84](https://github.com/koedame/rails-mermaid_erd/pull/84). Attach screenshots for UI changes.
+
+## Release flow
+
+Full procedure in `RELEASE.md`. Two-PR GitFlow pattern: from a single `release/vX.Y.Z` branch, open one PR into `develop` and another into `main` with the title `Release/vX.Y.Z` (empty body OK) — both must merge so the bump lands on both lines. `develop` is the default integration branch; `main` only moves on release. After merging, `rake build` and `rake release` run on the host (not the container) to push to RubyGems. SemVer applies: patch for bug fixes / dependency bumps, minor for backwards-compatible features, major for breaking changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache \
       alpine-sdk \
       git \
       postgresql-dev \
+      yaml-dev \
       chromium \
       chromium-chromedriver \
       libc6-compat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:3.4-alpine
 
 RUN apk add --no-cache \
       alpine-sdk \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM ruby:alpine
+FROM ruby:3.4-alpine
 
 ENV APP /app
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,6 +4,6 @@ ENV APP /app
 
 WORKDIR $APP
 
-RUN apk add --no-cache alpine-sdk git postgresql-dev
+RUN apk add --no-cache alpine-sdk git postgresql-dev yaml-dev
 
 RUN bundle config set path 'vendor/bundle'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,9 +40,11 @@ chromium-browser --headless --disable-gpu --no-sandbox --window-size=1280,800 --
 Stage the bump, the regenerated demo, and the screenshot, then commit them together with the message `vX.Y.Z` (matching prior history: `v0.6.0`, `v0.5.1`, …):
 
 ```bash
-git add lib/rails-mermaid_erd/version.rb docs/example.html docs/screen_shot.png
+git add lib/rails-mermaid_erd/version.rb Gemfile.lock docs/example.html docs/screen_shot.png
 git commit -m "vX.Y.Z"
 ```
+
+`Gemfile.lock` updates because the gemspec version flows into it on `bundle install`. Past release commits (`v0.6.0`, `v0.5.1`, `v0.5.0`) all include the same four paths.
 
 ### 3. Open the two release PRs
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,21 @@
 ## Perform a release
 
+The flow is GitFlow-style. Two PRs are opened from the same `release/vX.Y.Z` branch — one back into `develop`, one into `main` — so the version bump lands on both lines and `main` only ever advances on release. See merged PR pairs `#139`/`#140` (v0.6.0), `#127`/`#128` (v0.5.1), `#96`/`#97` (v0.5.0) for the pattern.
+
+Version bumping follows SemVer:
+- `patch` — bug fixes, dependency bumps, no API change
+- `minor` — new features that stay backwards-compatible (the default for most feature PRs in history)
+- `major` — breaking changes to the gem's public surface or generated output
+
+### 1. Cut the release branch
+
 ```bash
-git checkout -b release/vx.x.x
+git checkout develop
+git pull
+git checkout -b release/vX.Y.Z
 ```
 
-in docekr devcontainer:
+### 2. Bump, test, and regenerate the demo (inside the dev container)
 
 ```bash
 bundle install
@@ -26,10 +37,28 @@ cp -f /workspace/spec/dummy/mermaid_erd/index.html /workspace/docs/example.html
 chromium-browser --headless --disable-gpu --no-sandbox --window-size=1280,800 --hide-scrollbars --screenshot="/workspace/docs/screen_shot.png" /workspace/spec/dummy/mermaid_erd/index.html
 ```
 
-in host machine:
+Commit the bump, the regenerated `docs/example.html`, and the new `docs/screen_shot.png` with the message `vX.Y.Z` (matching prior history: `v0.6.0`, `v0.5.1`, …).
+
+### 3. Open the two release PRs
+
+Push the branch and open both PRs with the title `Release/vX.Y.Z` (body can be empty — the diff speaks for itself):
 
 ```bash
+git push -u origin release/vX.Y.Z
+gh pr create --base develop --head release/vX.Y.Z --title "Release/vX.Y.Z" --body ""
+gh pr create --base main    --head release/vX.Y.Z --title "Release/vX.Y.Z" --body ""
+```
+
+Wait for CI (`test`, `coding-style-check`) to pass on both, then merge them. Merge order doesn't matter as long as both land.
+
+### 4. Publish the gem (on the host machine, not in the container)
+
+```bash
+git checkout main
+git pull
 bundle install
 bundle exec rake build
 bundle exec rake release
 ```
+
+`rake release` tags the commit as `vX.Y.Z` and pushes to RubyGems. After release, confirm the new version at https://rubygems.org/gems/rails-mermaid_erd.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,7 +37,12 @@ cp -f /workspace/spec/dummy/mermaid_erd/index.html /workspace/docs/example.html
 chromium-browser --headless --disable-gpu --no-sandbox --window-size=1280,800 --hide-scrollbars --screenshot="/workspace/docs/screen_shot.png" /workspace/spec/dummy/mermaid_erd/index.html
 ```
 
-Commit the bump, the regenerated `docs/example.html`, and the new `docs/screen_shot.png` with the message `vX.Y.Z` (matching prior history: `v0.6.0`, `v0.5.1`, …).
+Stage the bump, the regenerated demo, and the screenshot, then commit them together with the message `vX.Y.Z` (matching prior history: `v0.6.0`, `v0.5.1`, …):
+
+```bash
+git add lib/rails-mermaid_erd/version.rb docs/example.html docs/screen_shot.png
+git commit -m "vX.Y.Z"
+```
 
 ### 3. Open the two release PRs
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,9 +42,11 @@ Note: The initial build may take several minutes as it needs to install system d
 
 3. Setup the test database
 ```bash
-# Create and migrate the test database for the dummy application
-docker compose exec -w /workspace/spec/dummy devcontainer bundle exec rails db:create db:migrate RAILS_ENV=test
+# Load schema.rb into the test database for the dummy application
+docker compose exec -w /workspace/spec/dummy devcontainer bundle exec rails db:setup RAILS_ENV=test
 ```
+
+`db:setup` runs `db:schema:load`, which matches what `.github/workflows/run-test.yml` does in CI. Use the same command in `CLAUDE.md` and `RELEASE.md`.
 
 4. Run tests to verify the setup
 ```bash
@@ -116,7 +118,7 @@ docker compose build --no-cache
 docker compose exec devcontainer bundle exec rspec
 
 # Access container shell
-docker compose exec devcontainer
+docker compose exec devcontainer sh
 ```
 
 ## Development Workflow
@@ -158,11 +160,11 @@ Outside contributors occasionally use bare slugs (e.g. `typo`, `readme-require-f
 - **No Conventional Commits prefix** (`feat:`, `fix:`, …) — the history doesn't use them. The one `docs:` example in `git log` is the exception, not the rule.
 - Examples drawn from merged history:
   - `Add zoom and drag mouse controls`
-  - `Migrate to Docker Compose V2` (PR title) → underlying commits `Rename compose files for Docker Compose V2`, `Update GitHub Actions workflows for Docker Compose V2`, `Remove .devcontainer`
+  - `Migrate to Docker Compose V2` (PR title) → underlying commits `Rename compose files for Docker Compose V2`, `Update GitHub Actions workflows for Docker Compose V2`, `Add development documentation`, `Remove .devcontainer`
   - `Fix a typo`
   - `Avoid unnecessary loading on Rails boot`
-  - `Support Apple Silicon (ARM64)`
-- Version-bump commits are plain `vX.Y.Z` (e.g. `v0.6.0`) — produced by `bundle exec bump`.
+  - `Add control hints`
+- Version-bump commits use the bare subject `vX.Y.Z` (e.g. `v0.6.0`). They are written by hand after `bundle exec bump <level> --no-commit` so the bump can be grouped with the regenerated `docs/example.html` and `docs/screen_shot.png` — see `RELEASE.md`.
 
 ### Pull requests
 - **Title**: same imperative-English convention as commits. The PR title is what reviewers and changelog readers see, so make it specific (`Add zoom and drag mouse controls`, not `Update viewer`).
@@ -188,14 +190,15 @@ All public-facing development artifacts are written in **English**:
 The README is bilingual (`README.md` / `README.ja.md`); when you change one, update the other in the same PR. UI strings in `lib/templates/index.html.erb` live in the `window.i18n` block and must be kept in sync between `en` and `ja`.
 
 ## CI/CD
-Two GitHub Actions workflows gate every push and PR to `main` / `develop`:
+Three GitHub Actions workflows run on each contribution:
 
-| Workflow                              | What it runs                                                     |
-| ------------------------------------- | ---------------------------------------------------------------- |
-| `.github/workflows/run-test.yml`      | `bundle exec rspec` against the dummy app on PostgreSQL 14       |
-| `.github/workflows/coding-style-check.yml` | `bundle exec standardrb` (StandardRb)                       |
+| Workflow                                    | Triggers                                              | What it runs                                                |
+| ------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------- |
+| `.github/workflows/run-test.yml`            | push / PR to `main` or `develop`                      | `bundle exec rspec` against the dummy app on PostgreSQL 14  |
+| `.github/workflows/coding-style-check.yml`  | push / PR to `main` or `develop`                      | `bundle exec standardrb` (StandardRb)                       |
+| `.github/workflows/codeql-analysis.yml`     | push / PR to `develop`, plus a weekly cron            | CodeQL Ruby analysis                                        |
 
-Both use `compose.ci.yml` (not `compose.yml`). A third workflow, `codeql-analysis.yml`, runs CodeQL on a schedule. Dependabot keeps Bundler and GitHub Actions versions current — its PRs are merged once CI is green.
+The first two use `compose.ci.yml` (not `compose.yml`). Dependabot watches three ecosystems — Docker, Bundler, and GitHub Actions (see `.github/dependabot.yml`) — and its PRs are merged once CI is green.
 
 ## Development Best Practices
 1. Add or extend tests in `spec/` before changing `Builder` behavior. The dummy app's models (`spec/dummy/app/models/*.rb`) are the contract — extend them to cover new association cases.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,28 +139,70 @@ The test suite includes coverage reporting via SimpleCov. The coverage report wi
 This project is released under the MIT License.
 
 ## Contributing
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Create a Pull Request
+
+The `develop` branch is the default integration branch; `main` only ever moves on release. All feature work targets `develop`.
+
+### Branch naming
+Pick the prefix that matches the change:
+
+| Purpose      | Pattern                  | Example                                |
+| ------------ | ------------------------ | -------------------------------------- |
+| New feature  | `feature/<kebab-case>`   | `feature/improve-erd-viewer-operation` |
+| Release      | `release/vX.Y.Z`         | `release/v0.6.0`                       |
+| Dependabot   | (auto-generated)         | `dependabot/bundler/rails-8.0.1`       |
+
+Outside contributors occasionally use bare slugs (e.g. `typo`, `readme-require-false`); maintainers keep the `feature/` prefix.
+
+### Commit messages
+- **English, imperative mood, single subject line.** No body unless truly needed.
+- **No Conventional Commits prefix** (`feat:`, `fix:`, …) — the history doesn't use them. The one `docs:` example in `git log` is the exception, not the rule.
+- Examples drawn from merged history:
+  - `Add zoom and drag mouse controls`
+  - `Migrate to Docker Compose V2` (PR title) → underlying commits `Rename compose files for Docker Compose V2`, `Update GitHub Actions workflows for Docker Compose V2`, `Remove .devcontainer`
+  - `Fix a typo`
+  - `Avoid unnecessary loading on Rails boot`
+  - `Support Apple Silicon (ARM64)`
+- Version-bump commits are plain `vX.Y.Z` (e.g. `v0.6.0`) — produced by `bundle exec bump`.
+
+### Pull requests
+- **Title**: same imperative-English convention as commits. The PR title is what reviewers and changelog readers see, so make it specific (`Add zoom and drag mouse controls`, not `Update viewer`).
+- **Base branch**: `develop` for everything except the release `→ main` PR (see `RELEASE.md`).
+- **Body**: small PRs ship with an empty body; that is accepted practice here. For anything non-trivial, follow the structure used in PR #84 ([Add table comments to SCHEMA_DATA.Models](https://github.com/koedame/rails-mermaid_erd/pull/84)):
+  ```markdown
+  ### Motivation / Background
+  <why this change is needed — link Rails docs / issues if relevant>
+
+  ### Detail
+  <what changed and any design notes a reviewer needs>
+  ```
+  For UI-affecting changes, attach a screenshot or short clip (PR #95 is an example).
+- **One PR ≈ one concern.** Multi-step refactors like #136 list the bullets in the body but stay scoped to a single theme.
+
+### Natural language
+All public-facing development artifacts are written in **English**:
+- Pull Request titles and descriptions
+- Issue titles and descriptions
+- Commit messages
+- Code comments, identifier names, and documentation under `/docs`
+
+The README is bilingual (`README.md` / `README.ja.md`); when you change one, update the other in the same PR. UI strings in `lib/templates/index.html.erb` live in the `window.i18n` block and must be kept in sync between `en` and `ja`.
 
 ## CI/CD
-GitHub Actions automates the following checks:
-- Test execution
-- Code style verification
-- Version management
+Two GitHub Actions workflows gate every push and PR to `main` / `develop`:
+
+| Workflow                              | What it runs                                                     |
+| ------------------------------------- | ---------------------------------------------------------------- |
+| `.github/workflows/run-test.yml`      | `bundle exec rspec` against the dummy app on PostgreSQL 14       |
+| `.github/workflows/coding-style-check.yml` | `bundle exec standardrb` (StandardRb)                       |
+
+Both use `compose.ci.yml` (not `compose.yml`). A third workflow, `codeql-analysis.yml`, runs CodeQL on a schedule. Dependabot keeps Bundler and GitHub Actions versions current — its PRs are merged once CI is green.
 
 ## Development Best Practices
-1. Write tests before modifying code
-2. Follow StandardRb coding conventions
-3. Update documentation
-4. Update CHANGELOG.md
-5. Use English for all development communications:
-   - Pull Request titles and descriptions
-   - Issue titles and descriptions
-   - Commit messages
-   - Code comments and documentation
+1. Add or extend tests in `spec/` before changing `Builder` behavior. The dummy app's models (`spec/dummy/app/models/*.rb`) are the contract — extend them to cover new association cases.
+2. Run `bundle exec standardrb` (or `--fix`) before pushing; CI fails on style violations.
+3. Update documentation in the same PR as the code change, including the bilingual README pair when relevant.
+4. Keep PRs focused on a single concern; split unrelated refactors into separate branches.
+5. Write all development communication in English (see [Natural language](#natural-language)).
 
 ## Troubleshooting
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,7 +46,7 @@ Note: The initial build may take several minutes as it needs to install system d
 docker compose exec -w /workspace/spec/dummy devcontainer bundle exec rails db:setup RAILS_ENV=test
 ```
 
-`db:setup` runs `db:schema:load`, which matches what `.github/workflows/run-test.yml` does in CI. Use the same command in `CLAUDE.md` and `RELEASE.md`.
+`db:setup` runs `db:schema:load`, which matches what `.github/workflows/run-test.yml` does in CI.
 
 4. Run tests to verify the setup
 ```bash


### PR DESCRIPTION
### Motivation / Background

The repository had no top-level `CLAUDE.md`, and `docs/DEVELOPMENT.md` / `RELEASE.md` covered Docker setup and the publish step but left the day-to-day conventions implicit. Anyone (human or LLM) opening the repo for the first time had to reverse-engineer branch naming, commit-message style, PR-body structure, the bilingual-README rule, and the two-PR release pattern from `git log` and `gh pr list`.

### Detail

- **New `CLAUDE.md`** — concise architecture map (Rake task → `Builder` → ERB template → single HTML), command quick-reference (RSpec, StandardRb, end-to-end generator run), the dummy-app-as-contract test strategy, and a "Contribution conventions" digest so Claude Code can apply the rules without re-reading the full guide.
- **Expanded `docs/DEVELOPMENT.md`** — replaced the boilerplate Contributing/Best-Practices block with sections derived from the merged history: branch naming table, commit-message rules (English, imperative, no Conventional Commits prefix, real examples from `git log`), PR-body template modeled on PR #84, Natural-language convention, CI/CD table covering all three workflows, and Dependabot scope.
- **Rewrote `RELEASE.md`** — documented the two-PR GitFlow pattern (one PR back into `develop`, one into `main` from the same `release/vX.Y.Z` branch), referenced the actual merged pairs `#139/#140`, `#127/#128`, `#96/#97`, and added explicit `git add` / `gh pr create` / `rake release` steps so a first-time releaser doesn't have to reconstruct the flow.

Three local review passes were run before opening this PR — `/security-review`, `pr-review-toolkit:code-reviewer`, and a project-specific accuracy audit cross-checking every cited command, path, PR number, commit subject, and source-code claim against the repository. Findings were resolved in commits `6a7083c` and `f958042`; the final round returned no remaining findings.