### PR TITLE
Fix has_many :through crash with polymorphic source

### DIFF
--- a/lib/rails-mermaid_erd/builder.rb
+++ b/lib/rails-mermaid_erd/builder.rb
@@ -89,6 +89,13 @@ class RailsMermaidErd::Builder
         end
 
         defined_model.reflect_on_all_associations(:belongs_to).each do |reflection|
+          # Polymorphic `belongs_to` has no concrete target class — the target is
+          # decided at row level by the `*_type` column. Emitting an edge to the
+          # macro name (e.g. `"Imageable"`) would render an orphan node with no
+          # columns; the polymorphic parents express the relationship via their
+          # `has_many ..., as: :foo` reflections instead.
+          next if reflection.polymorphic?
+
           reflection_model_name = get_reflection_model_name(reflection)
 
           reverse_relation = result[:Relations].find { |r| r[:RightModelName] == model[:ModelName] && r[:LeftModelName] == reflection_model_name }
@@ -152,8 +159,16 @@ class RailsMermaidErd::Builder
       if reflection.options[:class_name]
         reflection.options[:class_name].to_s.classify
       elsif reflection.options[:through]
-        if reflection.options[:source]
+        # `:source_type` is the authoritative class hint for a polymorphic
+        # `:source`, so it takes precedence over `:source` when both are set.
+        if reflection.options[:source_type]
+          reflection.options[:source_type].to_s.classify
+        elsif reflection.options[:source]
           reflection.options[:source].to_s.classify
+        elsif reflection.source_reflection.nil?
+          # `:through` targets a polymorphic `belongs_to` without `:source_type`;
+          # Rails can't resolve a single class. Fall back to its `:source` default.
+          reflection.name.to_s.classify
         else
           reflection.class_name
         end

--- a/spec/dummy/app/models/care_type.rb
+++ b/spec/dummy/app/models/care_type.rb
@@ -1,0 +1,10 @@
+class CareType < ApplicationRecord
+  has_many :matching_info_care_types
+  # Unresolvable polymorphic source — exercises the `source_reflection.nil?` fallback.
+  has_many :coordinator_matching_infos, through: :matching_info_care_types
+  # Explicit polymorphic disambiguation — exercises the `:source_type` branch.
+  has_many :caregiver_matchings,
+    through: :matching_info_care_types,
+    source: :matching_info,
+    source_type: "CaregiverMatchingInfo"
+end

--- a/spec/dummy/app/models/caregiver_matching_info.rb
+++ b/spec/dummy/app/models/caregiver_matching_info.rb
@@ -1,0 +1,4 @@
+class CaregiverMatchingInfo < ApplicationRecord
+  has_many :matching_info_care_types, as: :matching_info
+  has_many :care_types, through: :matching_info_care_types
+end

--- a/spec/dummy/app/models/coordinator_matching_info.rb
+++ b/spec/dummy/app/models/coordinator_matching_info.rb
@@ -1,0 +1,4 @@
+class CoordinatorMatchingInfo < ApplicationRecord
+  has_many :matching_info_care_types, as: :matching_info
+  has_many :care_types, through: :matching_info_care_types
+end

--- a/spec/dummy/app/models/matching_info_care_type.rb
+++ b/spec/dummy/app/models/matching_info_care_type.rb
@@ -1,0 +1,4 @@
+class MatchingInfoCareType < ApplicationRecord
+  belongs_to :care_type
+  belongs_to :matching_info, polymorphic: true
+end

--- a/spec/dummy/db/migrate/20260519120000_create_polymorphic_through_fixtures.rb
+++ b/spec/dummy/db/migrate/20260519120000_create_polymorphic_through_fixtures.rb
@@ -1,0 +1,28 @@
+class CreatePolymorphicThroughFixtures < ActiveRecord::Migration[7.1]
+  def change
+    create_table :care_types do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    create_table :coordinator_matching_infos do |t|
+      t.string :first_name
+
+      t.timestamps
+    end
+
+    create_table :caregiver_matching_infos do |t|
+      t.string :first_name
+
+      t.timestamps
+    end
+
+    create_table :matching_info_care_types do |t|
+      t.references :care_type, null: false, foreign_key: true
+      t.references :matching_info, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,68 +10,97 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_06_203417) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_120000) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "care_types", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "caregiver_matching_infos", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "first_name"
+    t.datetime "updated_at", null: false
+  end
 
   create_table "comments", force: :cascade do |t|
     t.string "body", null: false
-    t.bigint "post_id", null: false
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
+    t.bigint "post_id", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "posts", force: :cascade do |t|
-    t.string "title", null: false, comment: "post title"
-    t.bigint "user_id", null: false
+  create_table "coordinator_matching_infos", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "first_name"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "matching_info_care_types", force: :cascade do |t|
+    t.bigint "care_type_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "matching_info_id", null: false
+    t.string "matching_info_type", null: false
+    t.datetime "updated_at", null: false
+    t.index ["care_type_id"], name: "index_matching_info_care_types_on_care_type_id"
+    t.index ["matching_info_type", "matching_info_id"], name: "idx_on_matching_info_type_matching_info_id_de942d05f3"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "title", null: false, comment: "post title"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "posts_tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
     t.bigint "post_id", null: false
     t.bigint "tag_id", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_posts_tags_on_post_id"
     t.index ["tag_id"], name: "index_posts_tags_on_tag_id"
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string "name", null: false, comment: "always lowercase"
     t.datetime "created_at", null: false
+    t.string "name", null: false, comment: "always lowercase"
     t.datetime "updated_at", null: false
   end
 
   create_table "user_images", comment: "uploaded image by user", force: :cascade do |t|
-    t.string "image", null: false, comment: "Avatar image"
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
+    t.string "image", null: false, comment: "Avatar image"
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_images_on_user_id"
   end
 
   create_table "user_profiles", force: :cascade do |t|
     t.date "birthday", null: false, comment: "Birthday"
-    t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_profiles_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name", null: false, comment: "nickname"
-    t.string "email", null: false, comment: "login email"
     t.datetime "created_at", null: false
+    t.string "email", null: false, comment: "login email"
+    t.string "name", null: false, comment: "nickname"
     t.datetime "updated_at", null: false
   end
 
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "matching_info_care_types", "care_types"
   add_foreign_key "posts", "users"
   add_foreign_key "posts_tags", "posts"
   add_foreign_key "posts_tags", "tags"

--- a/spec/rails-mermaid_erd/builder/model_data_spec.rb
+++ b/spec/rails-mermaid_erd/builder/model_data_spec.rb
@@ -11,10 +11,10 @@ describe RailsMermaidErd::Builder.model_data do
       IsModelExist: true,
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
-        {name: "image", type: :string, key: "", comment: "Avatar image"},
-        {name: "user_id", type: :integer, key: "FK", comment: nil},
         {name: "created_at", type: :datetime, key: "", comment: nil},
-        {name: "updated_at", type: :datetime, key: "", comment: nil}
+        {name: "image", type: :string, key: "", comment: "Avatar image"},
+        {name: "updated_at", type: :datetime, key: "", comment: nil},
+        {name: "user_id", type: :integer, key: "FK", comment: nil}
       ]
     }, {
       TableName: "tags",
@@ -23,8 +23,8 @@ describe RailsMermaidErd::Builder.model_data do
       IsModelExist: true,
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
-        {name: "name", type: :string, key: "", comment: "always lowercase"},
         {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "name", type: :string, key: "", comment: "always lowercase"},
         {name: "updated_at", type: :datetime, key: "", comment: nil}
       ]
     }, {
@@ -34,9 +34,9 @@ describe RailsMermaidErd::Builder.model_data do
       IsModelExist: true,
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
+        {name: "created_at", type: :datetime, key: "", comment: nil},
         {name: "post_id", type: :integer, key: "FK", comment: nil},
         {name: "tag_id", type: :integer, key: "FK", comment: nil},
-        {name: "created_at", type: :datetime, key: "", comment: nil},
         {name: "updated_at", type: :datetime, key: "", comment: nil}
       ]
     }, {
@@ -46,10 +46,10 @@ describe RailsMermaidErd::Builder.model_data do
       IsModelExist: true,
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
-        {name: "title", type: :string, key: "", comment: "post title"},
-        {name: "user_id", type: :integer, key: "FK", comment: nil},
         {name: "created_at", type: :datetime, key: "", comment: nil},
-        {name: "updated_at", type: :datetime, key: "", comment: nil}
+        {name: "title", type: :string, key: "", comment: "post title"},
+        {name: "updated_at", type: :datetime, key: "", comment: nil},
+        {name: "user_id", type: :integer, key: "FK", comment: nil}
       ]
     }, {
       TableName: "comments",
@@ -59,10 +59,10 @@ describe RailsMermaidErd::Builder.model_data do
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
         {name: "body", type: :string, key: "", comment: nil},
-        {name: "post_id", type: :integer, key: "FK", comment: nil},
-        {name: "user_id", type: :integer, key: "FK", comment: nil},
         {name: "created_at", type: :datetime, key: "", comment: nil},
-        {name: "updated_at", type: :datetime, key: "", comment: nil}
+        {name: "post_id", type: :integer, key: "FK", comment: nil},
+        {name: "updated_at", type: :datetime, key: "", comment: nil},
+        {name: "user_id", type: :integer, key: "FK", comment: nil}
       ]
     }, {
       TableName: "user_profiles",
@@ -72,9 +72,9 @@ describe RailsMermaidErd::Builder.model_data do
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
         {name: "birthday", type: :date, key: "", comment: "Birthday"},
-        {name: "user_id", type: :integer, key: "FK", comment: nil},
         {name: "created_at", type: :datetime, key: "", comment: nil},
-        {name: "updated_at", type: :datetime, key: "", comment: nil}
+        {name: "updated_at", type: :datetime, key: "", comment: nil},
+        {name: "user_id", type: :integer, key: "FK", comment: nil}
       ]
     }, {
       TableName: "users",
@@ -83,9 +83,55 @@ describe RailsMermaidErd::Builder.model_data do
       IsModelExist: true,
       Columns: [
         {name: "id", type: :integer, key: "PK", comment: nil},
-        {name: "name", type: :string, key: "", comment: "nickname"},
-        {name: "email", type: :string, key: "", comment: "login email"},
         {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "email", type: :string, key: "", comment: "login email"},
+        {name: "name", type: :string, key: "", comment: "nickname"},
+        {name: "updated_at", type: :datetime, key: "", comment: nil}
+      ]
+    }, {
+      TableName: "care_types",
+      TableComment: "",
+      ModelName: "CareType",
+      IsModelExist: true,
+      Columns: [
+        {name: "id", type: :integer, key: "PK", comment: nil},
+        {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "name", type: :string, key: "", comment: nil},
+        {name: "updated_at", type: :datetime, key: "", comment: nil}
+      ]
+    }, {
+      TableName: "caregiver_matching_infos",
+      TableComment: "",
+      ModelName: "CaregiverMatchingInfo",
+      IsModelExist: true,
+      Columns: [
+        {name: "id", type: :integer, key: "PK", comment: nil},
+        {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "first_name", type: :string, key: "", comment: nil},
+        {name: "updated_at", type: :datetime, key: "", comment: nil}
+      ]
+    }, {
+      TableName: "coordinator_matching_infos",
+      TableComment: "",
+      ModelName: "CoordinatorMatchingInfo",
+      IsModelExist: true,
+      Columns: [
+        {name: "id", type: :integer, key: "PK", comment: nil},
+        {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "first_name", type: :string, key: "", comment: nil},
+        {name: "updated_at", type: :datetime, key: "", comment: nil}
+      ]
+    }, {
+      TableName: "matching_info_care_types",
+      TableComment: "",
+      ModelName: "MatchingInfoCareType",
+      IsModelExist: true,
+      Columns: [
+        {name: "id", type: :integer, key: "PK", comment: nil},
+        {name: "care_type_id", type: :integer, key: "FK", comment: nil},
+        {name: "created_at", type: :datetime, key: "", comment: nil},
+        {name: "matching_info_id", type: :integer, key: "", comment: nil},
+        {name: "matching_info_type", type: :string, key: "", comment: nil},
         {name: "updated_at", type: :datetime, key: "", comment: nil}
       ]
     }])
@@ -155,6 +201,41 @@ describe RailsMermaidErd::Builder.model_data do
       RightModelName: "Tag",
       RightValue: "||",
       Comment: "BT:tag"
+    }, {
+      LeftModelName: "CareType",
+      LeftValue: "||",
+      Line: "--",
+      RightModelName: "MatchingInfoCareType",
+      RightValue: "o{",
+      Comment: "HM:matching_info_care_types, BT:care_type"
+    }, {
+      LeftModelName: "CareType",
+      LeftValue: "}o",
+      Line: "..",
+      RightModelName: "CoordinatorMatchingInfo",
+      RightValue: "o{",
+      Comment: "HMT:coordinator_matching_infos, HMT:care_types"
+    }, {
+      LeftModelName: "CareType",
+      LeftValue: "}o",
+      Line: "..",
+      RightModelName: "CaregiverMatchingInfo",
+      RightValue: "o{",
+      Comment: "HMT:caregiver_matchings, HMT:care_types"
+    }, {
+      LeftModelName: "CaregiverMatchingInfo",
+      LeftValue: "||",
+      Line: "--",
+      RightModelName: "MatchingInfoCareType",
+      RightValue: "o{",
+      Comment: "HM:matching_info_care_types"
+    }, {
+      LeftModelName: "CoordinatorMatchingInfo",
+      LeftValue: "||",
+      Line: "--",
+      RightModelName: "MatchingInfoCareType",
+      RightValue: "o{",
+      Comment: "HM:matching_info_care_types"
     }])
   end
 end

--- a/spec/rails-mermaid_erd/rake_task_spec.rb
+++ b/spec/rails-mermaid_erd/rake_task_spec.rb
@@ -41,4 +41,42 @@ describe "rake mermaid_erd" do
     expect(generated_html).to include('globalThis["mermaid"]')    # Mermaid exposes itself globally
     expect(generated_html).to match(/var Vue\s*=/)                # Vue 3 global build
   end
+
+  # Regression guard: a table/column comment containing `</script>` must not
+  # close the SCHEMA_DATA script tag early. ActiveSupport's default JSON
+  # encoder escapes `<` and `>` as `<`/`>` (controlled by
+  # `ActiveSupport::JSON::Encoding.escape_html_entities_in_json`), so the
+  # hostile bytes never reach the rendered HTML. This test drives the
+  # actual rake task with hostile data so a future Rails change that flips
+  # that default would fail here instead of shipping a broken ERD.
+  it "renders SCHEMA_DATA safely when host-app metadata contains </script>" do
+    hostile = {
+      Models: [{
+        TableName: "evil",
+        TableComment: "</script><script>alert(1)</script>",
+        ModelName: "Evil",
+        IsModelExist: true,
+        Columns: [{name: "id", type: :integer, key: "PK", comment: nil}]
+      }],
+      Relations: []
+    }
+    tmp_path = Rails.root.join("tmp/mermaid_erd_escape_spec.html")
+    FileUtils.mkdir_p(File.dirname(tmp_path))
+
+    allow(RailsMermaidErd::Builder).to receive(:model_data).and_return(hostile)
+    allow(RailsMermaidErd.configuration).to receive(:result_path).and_return(tmp_path.relative_path_from(Rails.root).to_s)
+
+    Rake::Task["mermaid_erd"].reenable
+    Rake::Task["mermaid_erd"].invoke
+
+    # Slice the bytes between `window.SCHEMA_DATA=` and the next literal
+    # `</script>`. If hostile bytes reach the page unescaped, the first
+    # `</script>` lands inside the JSON, `payload` is truncated, and
+    # `JSON.parse` raises.
+    payload = File.read(tmp_path)[/window\.SCHEMA_DATA=(.*?)<\/script>/m, 1]
+    expect(payload).not_to be_nil
+    expect(JSON.parse(payload)).to eq(JSON.parse(hostile.to_json))
+  ensure
+    FileUtils.rm_f(tmp_path) if tmp_path
+  end
 end


### PR DESCRIPTION
Closes #144.

### Motivation / Background

`bundle exec rails mermaid_erd` aborts with `NoMethodError: undefined method 'class_name' for nil` when the host app has a `has_many :through` whose source is a polymorphic `belongs_to` on the join model with no `:source_type`. The crash originates in Rails' `ActiveRecord::Reflection::ThroughReflection#derive_class_name`, which dereferences a nil `source_reflection` for the unresolvable polymorphic source — but our `Builder` calls into it unguarded.

### Detail

**`get_reflection_model_name` (`lib/rails-mermaid_erd/builder.rb`)**
Replaces a previously-blanket `reflection.class_name` call with an explicit resolution order matching Rails' own:

1. `:source_type` (the polymorphic class hint takes precedence over `:source`)
2. `:source` (classify when the source is a regular association)
3. `source_reflection.nil?` → fall back to `reflection.name.classify` (same default Rails uses for `:source`)
4. `reflection.class_name` (the standard path)

No `rescue` — the discriminator is the structural state Rails itself uses, so future unrelated `NoMethodError`s still surface with real backtraces.

**Polymorphic `belongs_to` skip**
A polymorphic BT has no single target class, so emitting an edge to the macro name (e.g. `"Imageable"`) renders an orphan node with no columns. The inverse `has_many ..., as: :foo` reflections on the concrete parents already produce real edges, so no information is lost.

**Fixtures and tests**
- `spec/dummy/app/models/{care_type,matching_info_care_type,coordinator_matching_info,caregiver_matching_info}.rb` plus a migration introduce the polymorphic-`:through` shape from the issue. Reverting the builder change reproduces the original `NoMethodError` in CI.
- `CareType has_many :caregiver_matchings, source: :matching_info, source_type: "CaregiverMatchingInfo"` exercises the `:source_type` branch (previously untested).
- `model_data_spec` is rewritten to lock in alphabetical column ordering (Rails 8.1 schema dumper output) and the merged edges produced by the new builder.
- `rake_task_spec` adds a behavioural regression test that drives the rake task with hostile data (`</script>` in a `TableComment`) and verifies the rendered `SCHEMA_DATA` script tag cannot be broken out of — relies on `ActiveSupport::JSON::Encoding.escape_html_entities_in_json` (default true) and would fail loudly if that ever changed.

### Verification

- `bundle exec rspec` — 9 examples, 0 failures (line 94.31% / branch 83.93%)
- `bundle exec standardrb` — clean
- `bundle exec rails mermaid_erd` against the dummy app — generates the ERD without crashing
- Reverting `lib/rails-mermaid_erd/builder.rb` reproduces the original `NoMethodError` from #144 — confirming the new fixture pins the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)