### PR TITLE
Refresh marcel and zeitwerk to latest patch versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -325,7 +325,7 @@ GEM
       yard (>= 0.8)
     yard-solargraph (0.1.0)
       yard (~> 0.9)
-    zeitwerk (2.8.0)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   aarch64-linux-musl


### PR DESCRIPTION
### Motivation / Background

Running `bundle outdated` after the May 2026 dependency refresh (#165) surfaced only patch-level updates remaining for marcel and zeitwerk. Bundling them now keeps the lockfile current and clears the lingering stale Dependabot PRs that are already obsolete after #165.

### Detail

- `bundle update` inside the dev container
- marcel 1.1.0 → 1.1.1
- zeitwerk 2.8.0 → 2.8.1
- `bundle exec rspec` — 9 examples, 0 failures
- `bundle exec standardrb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)