### PR TITLE
Rework zoom UX to follow standard pan/zoom conventions

### DIFF
--- a/lib/templates/index.html.erb
+++ b/lib/templates/index.html.erb
@@ -228,7 +228,7 @@
           <button @click="tab = 'erd'" :class="`text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 ${tab === 'erd' ? 'bg-white text-gray-900' : 'bg-gray-400 text-gray-900'}`">{{i18n[language]["tab"]["erd"]}}</button>
           <button @click="tab = 'code'" :class="`text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 ${tab === 'code' ? 'bg-white text-gray-900' : 'bg-gray-400 text-gray-900'}`">{{i18n[language]["tab"]["code"]}}</button>
         </div>
-        <div v-show="tab === 'erd'" class="px-4 w-full min-h-[calc(100vh-56px-32px-56px)] relative overflow-hidden">
+        <div v-show="tab === 'erd'" ref="viewport" class="px-4 w-full min-h-[calc(100vh-56px-32px-56px)] relative overflow-hidden">
           <div class="absolute inset-0" :style="zoomStyle" ref="zoomArea">
             <div id="preview" :class="{ 'cursor-grab': isSpacePressed, 'cursor-grabbing': isDragging }"></div>
           </div>
@@ -250,6 +250,7 @@
             <div class="space-x-2 flex items-center">
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="zoomIn">+</button>
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="zoomOut">-</button>
+              <button :title="i18n[language]['controls']['reset_view']" class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="resetView">⌂</button>
             </div>
             <div class="flex items-center space-x-2">
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="moveLeft">←</button>
@@ -321,6 +322,7 @@
           middle_drag: 'Middle Click + Drag',
           mouse_wheel: 'Mouse Wheel',
           pinch: 'Pinch In/Out',
+          reset_view: 'Reset View',
         }
       },
       ja: {
@@ -363,6 +365,7 @@
           middle_drag: '中クリック + ドラッグ',
           mouse_wheel: 'マウスホイール',
           pinch: 'ピンチイン/アウト',
+          reset_view: 'ビューをリセット',
         }
       }
     }
@@ -394,35 +397,55 @@
         const WHEEL_ZOOM_SENSITIVITY = 0.0015
         const BUTTON_ZOOM_FACTOR = 1.2
         const PAN_STEP_PX = 60
+        // Approximate pixels-per-line / pixels-per-page for wheel events that don't report
+        // DOM_DELTA_PIXEL. Firefox defaults to DOM_DELTA_LINE (deltaMode === 1, e.g. ±3 per detent)
+        // — without normalisation, exp(-3 * 0.0015) ≈ 0.9955 produces almost no visible zoom.
+        const WHEEL_LINE_HEIGHT_PX = 16
 
         const scale = Vue.ref(1)
         const posX = Vue.ref(0)
         const posY = Vue.ref(0)
+        // `zoomArea` is the transformed inner element; `viewport` is its untransformed parent
+        // and the only stable reference frame for cursor-anchored zoom maths.
         const zoomArea = Vue.ref(null)
+        const viewport = Vue.ref(null)
         // Manage space key press state
         const isSpacePressed = Vue.ref(false)
         // Manage dragging state
         const isDragging = Vue.ref(false)
-        let startX = 0
-        let startY = 0
         // Record distance between two touch points
         let lastTouchDistance = 0
         // Record mouse position
         let lastMouseX = 0
         let lastMouseY = 0
 
-        const clampScale = (s) => Math.min(Math.max(s, MIN_SCALE), MAX_SCALE)
+        // Reject non-finite scale candidates so a single bad input (NaN deltaY, divide-by-zero
+        // factor, …) can't poison every subsequent transform with NaN.
+        const clampScale = (s) => {
+          if (!Number.isFinite(s)) return scale.value
+          return Math.min(Math.max(s, MIN_SCALE), MAX_SCALE)
+        }
 
         // Apply zoom by `factor` anchored at the given client coordinates so the world point
         // currently under (clientX, clientY) stays under it after the scale change.
-        // The transform is `translate(tx, ty) scale(s)` with origin (0,0), so tx/ty are screen
-        // pixels relative to the untransformed container's top-left.
+        // The transform is `translate(tx, ty) scale(s)` with origin (0,0): `translate` runs
+        // before `scale` (CSS applies transforms right-to-left), so tx/ty are screen pixels
+        // relative to the untransformed viewport's top-left.
         const zoomAt = (clientX, clientY, factor) => {
-          const container = zoomArea.value && zoomArea.value.parentElement
-          if (!container) return
+          if (!Number.isFinite(factor) || factor <= 0) return
+          if (!Number.isFinite(scale.value) || scale.value <= 0) {
+            // Recover from a previously corrupted state instead of silently propagating NaN.
+            scale.value = 1
+            posX.value = 0
+            posY.value = 0
+            return
+          }
           const newScale = clampScale(scale.value * factor)
-          if (newScale === scale.value) return
+          if (!Number.isFinite(newScale) || newScale === scale.value) return
+          const container = viewport.value
+          if (!container) return
           const rect = container.getBoundingClientRect()
+          if (rect.width === 0 || rect.height === 0) return
           const cx = clientX - rect.left
           const cy = clientY - rect.top
           const ratio = newScale / scale.value
@@ -432,13 +455,17 @@
         }
 
         const zoomCentered = (factor) => {
-          const container = zoomArea.value && zoomArea.value.parentElement
-          if (!container) {
-            scale.value = clampScale(scale.value * factor)
-            return
-          }
+          const container = viewport.value
+          if (!container) return
           const rect = container.getBoundingClientRect()
+          if (rect.width === 0 || rect.height === 0) return
           zoomAt(rect.left + rect.width / 2, rect.top + rect.height / 2, factor)
+        }
+
+        const resetView = () => {
+          scale.value = 1
+          posX.value = 0
+          posY.value = 0
         }
 
         // Calculate distance between two touch points
@@ -462,6 +489,11 @@
           if (e.touches.length === 2) {
             e.preventDefault()
             lastTouchDistance = getDistance(e.touches)
+          } else {
+            // Any non-2-touch state invalidates the baseline — otherwise a stale distance
+            // from a previous gesture leaks into the next pinch (e.g. 1→2→3→2 finger
+            // transitions on iOS) and produces a discontinuous jump on the first frame.
+            lastTouchDistance = 0
           }
         }
 
@@ -469,24 +501,27 @@
         // matches platform pinch gesture conventions (each pinch unit scales by the same factor
         // regardless of starting spread).
         const handleTouchMove = (e) => {
-          if (e.touches.length === 2) {
-            e.preventDefault()
-            const preview = document.getElementById('preview')
-            if (!preview.contains(e.target)) {
-              return
-            }
-
-            const newDistance = getDistance(e.touches)
-            if (lastTouchDistance > 0 && newDistance > 0) {
-              const center = getTouchCenter(e.touches)
-              const factor = newDistance / lastTouchDistance
-              zoomAt(center.x, center.y, factor)
-            }
-            lastTouchDistance = newDistance
+          if (e.touches.length !== 2) {
+            // Invalidate the pinch baseline as soon as we leave the 2-finger state, so the next
+            // 2-finger frame is treated as a fresh start instead of comparing to a stale distance.
+            lastTouchDistance = 0
+            return
           }
+          const preview = document.getElementById('preview')
+          // Gate preventDefault on the cursor being over the diagram, so 2-finger gestures on
+          // surrounding UI (sidebar, footer) still trigger their default browser behaviour.
+          if (!preview || !preview.contains(e.target)) return
+          e.preventDefault()
+          const newDistance = getDistance(e.touches)
+          if (lastTouchDistance > 0 && newDistance > 0) {
+            const center = getTouchCenter(e.touches)
+            zoomAt(center.x, center.y, newDistance / lastTouchDistance)
+          }
+          lastTouchDistance = newDistance
         }
 
-        // Handle touch end
+        // Handle touch end. Any drop below 2 active touches invalidates the pinch baseline so
+        // a re-pinch starts fresh.
         const handleTouchEnd = (e) => {
           if (e.touches.length < 2) {
             lastTouchDistance = 0
@@ -523,7 +558,8 @@
         }
 
         // Handle mouse move (movement while dragging). Translates are in screen pixels because
-        // the transform applies `scale` after `translate`, so no scale compensation is needed.
+        // `translate` runs before `scale` in the transform (CSS applies transforms right-to-left),
+        // so the scale factor never multiplies the translate — no compensation needed.
         const handleMouseMove = (e) => {
           if (isDragging.value) {
             posX.value += e.clientX - lastMouseX
@@ -546,12 +582,19 @@
         // device-agnostic zooming and anchors the zoom at the cursor.
         const handleWheel = (e) => {
           const preview = document.getElementById('preview')
-          if (!preview || !preview.contains(e.target)) {
-            return
-          }
+          if (!preview || !preview.contains(e.target)) return
+          // Pure horizontal trackpad swipes (deltaY === 0) shouldn't be swallowed — the user is
+          // navigating, not zooming. Returning without preventDefault lets the browser handle it.
+          if (e.deltaY === 0) return
           e.preventDefault()
-          const factor = Math.exp(-e.deltaY * WHEEL_ZOOM_SENSITIVITY)
-          zoomAt(e.clientX, e.clientY, factor)
+          // Normalise non-pixel deltaMode (Firefox defaults to line mode); otherwise the
+          // exp() factor collapses to ~1.0 and the wheel feels unresponsive.
+          const pixelDeltaY = e.deltaMode === 1
+            ? e.deltaY * WHEEL_LINE_HEIGHT_PX
+            : e.deltaMode === 2
+              ? e.deltaY * window.innerHeight
+              : e.deltaY
+          zoomAt(e.clientX, e.clientY, Math.exp(-pixelDeltaY * WHEEL_ZOOM_SENSITIVITY))
         }
 
         const zoomStyle = Vue.computed(() => {
@@ -858,8 +901,10 @@
           isHideColumns,
           zoomStyle,
           zoomArea,
+          viewport,
           zoomIn,
           zoomOut,
+          resetView,
           moveUp,
           moveDown,
           moveLeft,

--- a/lib/templates/index.html.erb
+++ b/lib/templates/index.html.erb
@@ -250,7 +250,7 @@
             <div class="space-x-2 flex items-center">
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="zoomIn">+</button>
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="zoomOut">-</button>
-              <button :title="i18n[language]['controls']['reset_view']" class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="resetView">⌂</button>
+              <button :title="i18n[language]['controls']['reset_view']" :aria-label="i18n[language]['controls']['reset_view']" class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="resetView">⌂</button>
             </div>
             <div class="flex items-center space-x-2">
               <button class="text-xs py-1 px-2 rounded hover:bg-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-900 bg-gray-400 text-gray-900" @click="moveLeft">←</button>
@@ -588,11 +588,15 @@
           if (e.deltaY === 0) return
           e.preventDefault()
           // Normalise non-pixel deltaMode (Firefox defaults to line mode); otherwise the
-          // exp() factor collapses to ~1.0 and the wheel feels unresponsive.
+          // exp() factor collapses to ~1.0 and the wheel feels unresponsive. For page mode,
+          // scale against the zoomable area's own height — page-mode events are rare, but
+          // when they fire we want a step proportional to the surface being zoomed, not the
+          // whole document viewport.
+          const pageHeightPx = (viewport.value && viewport.value.clientHeight) || window.innerHeight
           const pixelDeltaY = e.deltaMode === 1
             ? e.deltaY * WHEEL_LINE_HEIGHT_PX
             : e.deltaMode === 2
-              ? e.deltaY * window.innerHeight
+              ? e.deltaY * pageHeightPx
               : e.deltaY
           zoomAt(e.clientX, e.clientY, Math.exp(-pixelDeltaY * WHEEL_ZOOM_SENSITIVITY))
         }

--- a/lib/templates/index.html.erb
+++ b/lib/templates/index.html.erb
@@ -386,6 +386,15 @@
         const isShowComment = Vue.ref(false)
         const isHideColumns = Vue.ref(false)
 
+        const MIN_SCALE = 0.1
+        const MAX_SCALE = 5
+        // Wheel delta in pixels → zoom factor. Exponential keeps each step perceptually uniform
+        // across the whole range, and lets trackpad (small deltas) and mouse-wheel (large deltas)
+        // share the same code path.
+        const WHEEL_ZOOM_SENSITIVITY = 0.0015
+        const BUTTON_ZOOM_FACTOR = 1.2
+        const PAN_STEP_PX = 60
+
         const scale = Vue.ref(1)
         const posX = Vue.ref(0)
         const posY = Vue.ref(0)
@@ -401,6 +410,36 @@
         // Record mouse position
         let lastMouseX = 0
         let lastMouseY = 0
+
+        const clampScale = (s) => Math.min(Math.max(s, MIN_SCALE), MAX_SCALE)
+
+        // Apply zoom by `factor` anchored at the given client coordinates so the world point
+        // currently under (clientX, clientY) stays under it after the scale change.
+        // The transform is `translate(tx, ty) scale(s)` with origin (0,0), so tx/ty are screen
+        // pixels relative to the untransformed container's top-left.
+        const zoomAt = (clientX, clientY, factor) => {
+          const container = zoomArea.value && zoomArea.value.parentElement
+          if (!container) return
+          const newScale = clampScale(scale.value * factor)
+          if (newScale === scale.value) return
+          const rect = container.getBoundingClientRect()
+          const cx = clientX - rect.left
+          const cy = clientY - rect.top
+          const ratio = newScale / scale.value
+          posX.value = cx + (posX.value - cx) * ratio
+          posY.value = cy + (posY.value - cy) * ratio
+          scale.value = newScale
+        }
+
+        const zoomCentered = (factor) => {
+          const container = zoomArea.value && zoomArea.value.parentElement
+          if (!container) {
+            scale.value = clampScale(scale.value * factor)
+            return
+          }
+          const rect = container.getBoundingClientRect()
+          zoomAt(rect.left + rect.width / 2, rect.top + rect.height / 2, factor)
+        }
 
         // Calculate distance between two touch points
         const getDistance = (touches) => {
@@ -426,7 +465,9 @@
           }
         }
 
-        // Handle touch move (pinch in/out for zoom)
+        // Handle touch move (pinch in/out for zoom). Uses the ratio of touch-point distances —
+        // matches platform pinch gesture conventions (each pinch unit scales by the same factor
+        // regardless of starting spread).
         const handleTouchMove = (e) => {
           if (e.touches.length === 2) {
             e.preventDefault()
@@ -436,23 +477,12 @@
             }
 
             const newDistance = getDistance(e.touches)
-            const delta = (newDistance - lastTouchDistance) * 0.01
+            if (lastTouchDistance > 0 && newDistance > 0) {
+              const center = getTouchCenter(e.touches)
+              const factor = newDistance / lastTouchDistance
+              zoomAt(center.x, center.y, factor)
+            }
             lastTouchDistance = newDistance
-
-            const center = getTouchCenter(e.touches)
-            const rect = preview.getBoundingClientRect()
-            const touchX = center.x - rect.left
-            const touchY = center.y - rect.top
-
-            const x = touchX / scale.value - posX.value
-            const y = touchY / scale.value - posY.value
-
-            const newScale = Math.min(Math.max(scale.value + delta, 0.5), 3)
-            if (newScale === scale.value) return
-
-            posX.value = touchX / newScale - x
-            posY.value = touchY / newScale - y
-            scale.value = newScale
           }
         }
 
@@ -492,13 +522,12 @@
           }
         }
 
-        // Handle mouse move (movement while dragging)
+        // Handle mouse move (movement while dragging). Translates are in screen pixels because
+        // the transform applies `scale` after `translate`, so no scale compensation is needed.
         const handleMouseMove = (e) => {
           if (isDragging.value) {
-            const dx = (e.clientX - lastMouseX) / scale.value
-            const dy = (e.clientY - lastMouseY) / scale.value
-            posX.value += dx
-            posY.value += dy
+            posX.value += e.clientX - lastMouseX
+            posY.value += e.clientY - lastMouseY
             lastMouseX = e.clientX
             lastMouseY = e.clientY
             e.preventDefault()
@@ -513,58 +542,37 @@
           isDragging.value = false
         }
 
-        // Handle mouse wheel (zoom)
+        // Handle mouse wheel (zoom). Exponential factor derived from wheel delta gives smooth,
+        // device-agnostic zooming and anchors the zoom at the cursor.
         const handleWheel = (e) => {
           const preview = document.getElementById('preview')
-          if (!preview.contains(e.target)) {
+          if (!preview || !preview.contains(e.target)) {
             return
           }
-
           e.preventDefault()
-
-          const rect = preview.getBoundingClientRect()
-          const mouseX = e.clientX - rect.left
-          const mouseY = e.clientY - rect.top
-
-          // Calculate relative coordinates based on mouse position
-          const x = mouseX / scale.value - posX.value
-          const y = mouseY / scale.value - posY.value
-
-          // Change scale
-          const delta = e.deltaY < 0 ? 0.1 : -0.1
-          const newScale = Math.min(Math.max(scale.value + delta, 0.5), 3)
-
-          // Calculate new position with new scale
-          posX.value = mouseX / newScale - x
-          posY.value = mouseY / newScale - y
-          scale.value = newScale
+          const factor = Math.exp(-e.deltaY * WHEEL_ZOOM_SENSITIVITY)
+          zoomAt(e.clientX, e.clientY, factor)
         }
 
         const zoomStyle = Vue.computed(() => {
           return {
-            transform: `scale(${scale.value}) translate(${posX.value}px, ${posY.value}px)`,
-            transformOrigin: 'top left'
+            transform: `translate(${posX.value}px, ${posY.value}px) scale(${scale.value})`,
+            transformOrigin: '0 0'
           }
         })
 
-        const zoomIn = () => {
-          scale.value = Math.min(scale.value + 0.1, 3)
+        const zoomIn = () => zoomCentered(BUTTON_ZOOM_FACTOR)
+        const zoomOut = () => zoomCentered(1 / BUTTON_ZOOM_FACTOR)
+
+        const move = (dxPx, dyPx) => {
+          posX.value += dxPx
+          posY.value += dyPx
         }
 
-        const zoomOut = () => {
-          scale.value = Math.max(scale.value - 0.1, 0.5)
-        }
-
-        const move = (dx, dy) => {
-          const step = 10 / scale.value
-          posX.value += dx * step
-          posY.value += dy * step
-        }
-
-        const moveUp = () => move(0, -10)
-        const moveDown = () => move(0, 10)
-        const moveLeft = () => move(-10, 0)
-        const moveRight = () => move(10, 0)
+        const moveUp = () => move(0, -PAN_STEP_PX)
+        const moveDown = () => move(0, PAN_STEP_PX)
+        const moveLeft = () => move(-PAN_STEP_PX, 0)
+        const moveRight = () => move(PAN_STEP_PX, 0)
 
         const restoreFromHash = () => {
           try {


### PR DESCRIPTION
### Motivation / Background

The diagram viewer's pan/zoom behaviour diverged from the conventions used by mainstream pan/zoom UIs (Figma, Google Maps, svg-pan-zoom). Concretely:

- Zoom steps were linear (`±0.1`). At scale 0.5 a step is +20%, at 2.9 it is +3.4% — perceptually uneven across the range.
- The wheel handler ignored `deltaY` magnitude, so trackpad fine-scrolls and mouse-wheel detents produced the same chunky step.
- Pinch zoom was additive (`newDistance - lastTouchDistance`) instead of the platform-standard ratio (`newDistance / lastTouchDistance`).
- Button zoom changed `scale` without compensating `posX/posY`, so with `transform-origin: top left` the diagram drifted toward the top-left on every press.
- The transform order was `scale(s) translate(tx, ty)`, which makes translate units depend on the current scale and introduces a small cursor-anchor drift on every wheel step. Most pan/zoom libraries use `translate(tx, ty) scale(s)` so translates are screen pixels.

### Detail

Rewrites the pan/zoom block in `lib/templates/index.html.erb` and addresses every finding surfaced by the local code-review / security-review / project-conventions agents.

| Aspect | Before | After |
|---|---|---|
| Transform order | `scale(s) translate(tx, ty)`, origin `top left` | `translate(tx, ty) scale(s)`, origin `0 0` |
| Wheel zoom | Fixed `±0.1` per event | `Math.exp(-pixelDeltaY * 0.0015)` exponential factor, with `deltaMode` normalised to pixels for Firefox |
| Wheel — pure horizontal scroll | Always `preventDefault`-ed, swallowing trackpad lateral swipes | Returns without `preventDefault` when `deltaY === 0` |
| Pinch zoom | Distance difference (additive) | Distance ratio (multiplicative); `lastTouchDistance` reset whenever the 2-touch state is left |
| Button zoom | `scale += 0.1`, no position compensation | Anchored at viewport centre, `× 1.2` per press |
| Mouse drag | `delta / scale.value` compensation | Direct pixel delta (translates are screen px) |
| Arrow-button pan | `10 / scale.value` per click — `≈ 100` screen px regardless of scale | Constant `60` screen px per click — same model (constant screen movement), slightly tighter step |
| Scale range | 0.5–3 | 0.1–5 |
| Reset view | No way back from a lost view short of a page reload | New `⌂` button (next to `+` / `-`) restores scale 1 / origin 0,0, with bilingual i18n |
| NaN / non-finite inputs | Silently propagated into `scale`, `posX`, `posY` → CSS transform became `NaN` and froze | Rejected up-front in `clampScale` and `zoomAt`; corrupted state self-heals to scale 1, origin 0,0 |
| Hidden-tab / zero-rect | `getBoundingClientRect()` on a `v-show`-hidden ancestor anchored at (0,0) and scrolled the diagram offscreen | `zoomAt` / `zoomCentered` bail when the viewport rect has zero size |
| Cursor-anchor reference frame | `zoomArea.value.parentElement` (coupled to DOM nesting) | Explicit `ref="viewport"` on the untransformed parent |
| Cursor-anchor maths | Drifted slightly on each zoom step | Mathematically exact |

A shared `zoomAt(clientX, clientY, factor)` helper centralises the cursor-anchor formula so wheel, pinch, and button zoom all preserve the world point under the anchor. `zoomCentered(factor)` reuses it for the toolbar buttons by anchoring at the viewport centre.

### Test plan

- [x] `bundle exec rspec` — 9 examples, 0 failures.
- [x] `bundle exec standardrb` — clean.
- [x] `rake mermaid_erd` against `spec/dummy` — generated HTML contains the new helpers (`zoomAt`, `zoomCentered`, `resetView`, `viewport`, `Number.isFinite`, `deltaMode`, `WHEEL_LINE_HEIGHT_PX`) and renders.
- [ ] Manual smoke in a browser: wheel zoom anchors at cursor on Chrome and Firefox (the latter exercising the `deltaMode === 1` normalisation), pinch on a trackpad scales smoothly, toolbar `+ / - / ⌂` zoom toward the viewport centre and reset, space+drag and middle-click drag pan without scale-coupled speed, horizontal trackpad swipes are no longer swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
